### PR TITLE
fix: the decimal value of the default mount mode for TLS secrets

### DIFF
--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -1251,11 +1251,10 @@ type TLS struct {
 	// +kubebuilder:validation:Required
 	MountPath string `json:"mountPath"`
 
-	// The default permissions for the mounted path.
+	// The permissions for the mounted path. Defaults to 0600.
 	//
 	// This field is immutable once set.
 	//
-	// +kubebuilder:default=0600
 	// +optional
 	DefaultMode *int32 `json:"defaultMode,omitempty"`
 

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -16772,9 +16772,8 @@ spec:
                       This field is immutable once set.
                     type: string
                   defaultMode:
-                    default: 600
                     description: |-
-                      The default permissions for the mounted path.
+                      The permissions for the mounted path. Defaults to 0600.
 
 
                       This field is immutable once set.

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -16772,9 +16772,8 @@ spec:
                       This field is immutable once set.
                     type: string
                   defaultMode:
-                    default: 600
                     description: |-
-                      The default permissions for the mounted path.
+                      The permissions for the mounted path. Defaults to 0600.
 
 
                       This field is immutable once set.

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -11174,7 +11174,7 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>The default permissions for the mounted path.</p>
+<p>The permissions for the mounted path. Defaults to 0600.</p>
 <p>This field is immutable once set.</p>
 </td>
 </tr>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the default mount mode for TLS secrets from octal 0600 to decimal 384.